### PR TITLE
Add an alias for dynamic-completion-table obsolete in Emacs 28

### DIFF
--- a/rosemacs/rosemacs.el
+++ b/rosemacs/rosemacs.el
@@ -381,6 +381,9 @@
 ;; Completion
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define-obsolete-function-alias
+  'dynamic-completion-table 'completion-table-dynamic "23.1")
+
 (defun current-ros-word (&optional package)
   "wraps (current-word) from simple.el to pick what is most likely a package, topic, message or action name"
   (let* ((word (current-word nil nil)) ;; neither strict nor just the symbol


### PR DESCRIPTION
Add an alias for dynamic-completion-table obsolete in Emacs 28 (see: https://www.masteringemacs.org/article/whats-new-in-emacs-28-1)

I've added these lines to my init.el and it is working as expected.
I think putting these lines here will let people continue to use the package in Emacs 28 without changing their init.el this way.

I'm new to tinkering with emacs and programming in common lisp in general,
so I'm not really sure if I did this in the right way.